### PR TITLE
ラインデバッグに対応する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ tmp
 tmp.s
 src/*.o
 src/*.d
+dev/cc.dwarf
+dev/cc.o
+dev/cc.s
+dev/mcc2.o
+dev/mcc2.s
+dev/mcc2.dwarf
 test.exe
 test/c/*.o
 test/c/*.d

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 mcc2
 tmp
 tmp.s
+dwarf_test
 src/*.o
 src/*.d
 dev/cc.dwarf

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
             "name": "(gdb) 起動",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/selfhost/mcc2t",
+//            "program": "${workspaceFolder}/dev/mcc2.o",
+            "program": "${workspaceFolder}/dwarf_test",
             "args": [
                 "-c", "${workspaceFolder}/test/c/statement.c",
                 "-o", "${workspaceFolder}/tmp.s",

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ test : mcc2 $(TEST_OBJS)
 	cc -o test.exe $(TEST_OBJS)
 	./test.exe
 
+tdwarf : mcc2
+	cc ./dev/dwarf_test.c -o ./dev/cc.s -S -g
+	cc -c -o ./dev/cc.o ./dev/cc.s -lc -MD
+	readelf -w ./dev/cc.o > ./dev/cc.dwarf
+
+	./mcc2 -c ./dev/dwarf_test.c -o ./dev/mcc2.s -i ./test/testinc -i ./src -x plvar -g
+	cc -c -o ./dev/mcc2.o ./dev/mcc2.s -lc -MD
+	readelf -w ./dev/mcc2.o > ./dev/mcc2.dwarf
+
 test2: mcc2
 	./mcc2 -c ./dev/test2.c -o ./tmp.s -i ./test/testinc -i ./src -x plvar -g
 	cc -o ./dev/tmp -no-pie tmp.s -lc

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ dwarf : mcc2
 	cc -c -o ./dev/mcc2.o ./dev/mcc2.s -lc -MD
 	readelf -w ./dev/mcc2.o > ./dev/mcc2.dwarf
 
+	cc -o dwarf_test ./dev/mcc2.o -lc
+
 test2: mcc2
 	./mcc2 -c ./dev/test2.c -o ./tmp.s -i ./test/testinc -i ./src -x plvar -g
 	cc -o ./dev/tmp -no-pie tmp.s -lc
@@ -44,25 +46,25 @@ tmp: mcc2
 
 ./selfhost/mcc2t: mcc2
 	./mcc2 -c ./src/builtin_def.c -d PREDEFINED_MACRO -o ./selfhost/builtin_def.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/builtin_def.o -no-pie ./selfhost/builtin_def.s -lc -MD
+	cc -c -o ./selfhost/builtin_def.o -no-pie ./selfhost/builtin_def.s -lc -MD -g
 
 	./mcc2 -c ./src/error.c -d PREDEFINED_MACRO -o ./selfhost/error.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/error.o -no-pie ./selfhost/error.s -lc -MD
+	cc -c -o ./selfhost/error.o -no-pie ./selfhost/error.s -lc -MD -g
 
 	./mcc2 -c ./src/file.c -d PREDEFINED_MACRO -o ./selfhost/file.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/file.o -no-pie ./selfhost/file.s -lc -MD
+	cc -c -o ./selfhost/file.o -no-pie ./selfhost/file.s -lc -MD -g
 
 	./mcc2 -c ./src/gen_ir.c -d PREDEFINED_MACRO -o ./selfhost/get_ir.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/gen_ir.o -no-pie ./selfhost/get_ir.s -lc -MD
+	cc -c -o ./selfhost/gen_ir.o -no-pie ./selfhost/get_ir.s -lc -MD -g
 
 	./mcc2 -c ./src/semantics.c -d PREDEFINED_MACRO -o ./selfhost/semantics.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/semantics.o -no-pie ./selfhost/semantics.s -lc -MD
+	cc -c -o ./selfhost/semantics.o -no-pie ./selfhost/semantics.s -lc -MD -g
 
 	./mcc2 -c ./src/utility.c -d PREDEFINED_MACRO -o ./selfhost/utility.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/utility.o -no-pie ./selfhost/utility.s -lc -MD
+	cc -c -o ./selfhost/utility.o -no-pie ./selfhost/utility.s -lc -MD -g
 
 	./mcc2 -c ./src/type.c -d PREDEFINED_MACRO -o ./selfhost/type.s -i ./src -x plvar -g
-	cc -c -o ./selfhost/type.o -no-pie ./selfhost/type.s -lc -MD
+	cc -c -o ./selfhost/type.o -no-pie ./selfhost/type.s -lc -MD -g
 
 	cp ./src/gen_x86_64.o ./selfhost/gen_x86_64.o
 	cp ./src/main.o ./selfhost/main.o

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test : mcc2 $(TEST_OBJS)
 	cc -o test.exe $(TEST_OBJS)
 	./test.exe
 
-tdwarf : mcc2
+dwarf : mcc2
 	cc ./dev/dwarf_test.c -o ./dev/cc.s -S -g
 	cc -c -o ./dev/cc.o ./dev/cc.s -lc -MD
 	readelf -w ./dev/cc.o > ./dev/cc.dwarf
@@ -71,6 +71,7 @@ tmp: mcc2
 	cp ./src/ident.o ./selfhost/ident.o
 	cp ./src/preprocess.o ./selfhost/preprocess.o
 	cp ./src/pre_macro_map.o ./selfhost/pre_macro_map.o
+	cp ./src/dwarf.o ./selfhost/dwarf.o
 
 	#cp ./src/file.o ./selfhost/file.o
 
@@ -94,4 +95,4 @@ clean:
 	rm -f ./selfhost/*.o ./selfhost/*.s ./selfhost/mcc2t
 	rm -f ./selfhost/test/c/*.o ./selfhost/test/c/*.s
 
-.PHONY: test clean tmp test2 test3 test4 self selft
+.PHONY: test clean tmp test2 test3 test4 self selft dwarf

--- a/dev/dwarf_test.c
+++ b/dev/dwarf_test.c
@@ -1,7 +1,7 @@
 // #include "dwarf_test.h"
 
 int a = 1;
-
+char c = 10;
 int main(int a){
     return 0;
 }

--- a/dev/dwarf_test.c
+++ b/dev/dwarf_test.c
@@ -1,0 +1,7 @@
+// #include "dwarf_test.h"
+
+int a = 1;
+
+int main(int a){
+    return 0;
+}

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -1,5 +1,6 @@
 #include "mcc2.h"
 #include "dwarf.h"
+#include <unistd.h>
 
 static int g_asf = 0;           // .debug_str用のラベル
 static Dwarf_dstr* g_dstr;      // .debug_str用の文字列テーブル
@@ -28,9 +29,14 @@ void dwarf(){
 
 static void dwarf_init(){
     // debug_strをつくる
-    DWARF_Str("/workspaces/mcc2");       // 作業ディレクトリ
-    DWARF_Str(cinfo.compile_file);      // コンパイルファイル
-    DWARF_Str(cinfo.compiler);          // コンパイラ
+
+    //カレントディレクトリを取得
+    char cwd[1024];
+    getcwd(cwd, 1024);
+
+    DWARF_Str(cwd);                         // 作業ディレクトリ
+    DWARF_Str(cinfo.compile_file->path);    // コンパイルファイル
+    DWARF_Str(cinfo.compiler);              // コンパイラ
 }
 
 // .debug_abbrevの出力

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -3,19 +3,30 @@
 
 static int g_asf = 0;           // .debug_str用のラベル
 static Dwarf_dstr* g_dstr;      // .debug_str用の文字列テーブル
+static Dwarf_dstr* g_dstr_end;  // .debug_str用の文字列テーブルの最後
 
+static void dwarf_init();       // 初期化
 static void dwarf_abbrev();     // .debug_abbrev
 static void dwarf_info();       // .debug_info
 static void dwarf_str();        // .debug_str
 static void dwarf_line();       // .debug_line
 
-static void DWARF_Str(char* fmt, ...);
+static Dwarf_dstr* DWARF_Str(char* fmt, ...);
 
 void dwarf(){
+    dwarf_init();
+
     dwarf_abbrev();
     dwarf_info();
     dwarf_line();
     dwarf_str();
+}
+
+static void dwarf_init(){
+    // debug_strをつくる
+    DWARF_Str(cinfo.working_dir);       // 作業ディレクトリ
+    DWARF_Str(cinfo.compile_file);      // コンパイルファイル
+    DWARF_Str(cinfo.compiler);          // コンパイラ
 }
 
 // .debug_abbrevの出力
@@ -40,10 +51,14 @@ static void dwarf_str(){
     // セクション宣言
     print("\t.section\t.debug_str, \"MS\",@progbits,1\n");
 
+    for(Dwarf_dstr* dstr = g_dstr; dstr != NULL; dstr = dstr->next){
+        print(".LASF%d:\n", dstr->id);
+        print("\t.string \"%s\"\n", dstr->str);
+    }
 }
 
 
-static void DWARF_Str(char* fmt, ...){
+static Dwarf_dstr* DWARF_Str(char* fmt, ...){
     va_list ap;
     va_start(ap, fmt);
 
@@ -56,9 +71,14 @@ static void DWARF_Str(char* fmt, ...){
     va_end(ap);
 
     Dwarf_dstr* dstr = calloc(1, sizeof(Dwarf_dstr));
-    dstr->id = g_asf;
+    dstr->id = g_asf++;
     dstr->str = buf;
 
-    print(".LASF%d:\n", g_asf++);
-    print("\t.string \"%s\"\n", buf);
+    if(g_dstr == NULL){
+        g_dstr = dstr;
+        g_dstr_end = dstr;
+    }
+
+    g_dstr_end->next = dstr;
+    g_dstr_end = dstr;
 }

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -14,6 +14,7 @@ static void dwarf_info();       // .debug_info
 static void dwarf_str();        // .debug_str
 static void dwarf_line();       // .debug_line
 
+static void dwarf_info_compile_unit();  // コンパイルユニットの情報
 static Dwarf_dstr* DWARF_Str(char* fmt, ...);
 
 void dwarf(){
@@ -65,16 +66,28 @@ static void dwarf_info(){
     print(".Ldebug_info0:\n");
 
     // debug_infoのヘッダ
-    print("  .long .Ledebug_info0 - .Ldebug_info0 - 4\n");  // Length
-    print("  .short 0x0005\n");                             // DWARF version
-    print("  .byte 0x01\n");                                // UnitType : DW_UT_compile
-    print("  .byte 0x08\n");                                // AddressSize
-    print("  .long 0x00\n");                                // AbbrevOffset
+    print("\t.long .Ledebug_info0 - .Ldebug_info0 - 4\n");  // Length
+    print("\t.short 0x0005\n");                             // DWARF version
+    print("\t.byte 0x01\n");                                // UnitType : DW_UT_compile
+    print("\t.byte 0x08\n");                                // AddressSize
+    print("\t.long 0x00\n");                                // AbbrevOffset
 
     // 0x01 Compilation Unit
     // コンパイル情報だけはここで出す
+    dwarf_info_compile_unit();
 
     print(".Ledebug_info0:\n");
+}
+
+static void dwarf_info_compile_unit(){
+    print("\t.uleb128 0x01\n"); // Abbreviation Code;
+    print("\t.long .LASF2\n");  // DW_AT_producer
+    print("\t.byte 0x01\n");    // DW_AT_language
+    print("\t.long .LASF1\n");  // DW_AT_name
+    print("\t.long .LASF0\n");  // DW_AT_comp_dir
+    print("\t.quad .Ltext0\n"); // DW_AT_low_pc
+    print("\t.quad .Letext0-.Ltext0\n"); // DW_AT_high_pc
+    print("\t.long .Ldebug_line0\n"); // DW_AT_stmt_list
 }
 
 // .debug_lineの出力

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -4,6 +4,9 @@
 static int g_asf = 0;           // .debug_str用のラベル
 static Dwarf_dstr* g_dstr;      // .debug_str用の文字列テーブル
 static Dwarf_dstr* g_dstr_end;  // .debug_str用の文字列テーブルの最後
+static Scope* g_scope;          // グローバルスコープ
+
+static int g_abbrev_idx = 1;    // .debug_abbrev用のインデックス
 
 static void dwarf_init();       // 初期化
 static void dwarf_abbrev();     // .debug_abbrev
@@ -31,12 +34,47 @@ static void dwarf_init(){
 
 // .debug_abbrevの出力
 static void dwarf_abbrev(){
+    // セクション宣言とラベル
+    print("\t.section\t.debug_abbrev, \"\",@progbits\n");
+    print(".Ldebug_abbrev0:\n");
 
+    // 0x01 Compilation Unit
+    // コンパイル情報だけはここで出す
+    DW_ABBREV_IDX();
+    DW_ABBREV_TAG(DW_TAG_compile_unit);
+    DW_CHILDREN_no();
+
+    DW_ATTR(DW_AT_producer, DW_FORM_strp);
+    DW_ATTR(DW_AT_language, DW_FORM_data1);
+    DW_ATTR(DW_AT_name, DW_FORM_strp);
+    DW_ATTR(DW_AT_comp_dir, DW_FORM_strp);
+    DW_ATTR(DW_AT_low_pc, DW_FORM_addr);
+    DW_ATTR(DW_AT_high_pc, DW_FORM_data8);
+    DW_ATTR(DW_AT_stmt_list, DW_FORM_sec_offset);
+    DW_ATTR(0x00, 0x00);
+
+    // TODO : いろいろだす
+
+    DW_ATTR(0x00, 0x00);
 }
 
 // .debug_infoの出力
 static void dwarf_info(){
+    // セクション宣言とラベル
+    print("\t.section\t.debug_info, \"\",@progbits\n");
+    print(".Ldebug_info0:\n");
 
+    // debug_infoのヘッダ
+    print("  .long .Ledebug_info0 - .Ldebug_info0 - 4\n");  // Length
+    print("  .short 0x0005\n");                             // DWARF version
+    print("  .byte 0x01\n");                                // UnitType : DW_UT_compile
+    print("  .byte 0x08\n");                                // AddressSize
+    print("  .long 0x00\n");                                // AbbrevOffset
+
+    // 0x01 Compilation Unit
+    // コンパイル情報だけはここで出す
+
+    print(".Ledebug_info0:\n");
 }
 
 // .debug_lineの出力

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -28,7 +28,7 @@ void dwarf(){
 
 static void dwarf_init(){
     // debug_strをつくる
-    DWARF_Str(cinfo.working_dir);       // 作業ディレクトリ
+    DWARF_Str("/workspaces/mcc2");       // 作業ディレクトリ
     DWARF_Str(cinfo.compile_file);      // コンパイルファイル
     DWARF_Str(cinfo.compiler);          // コンパイラ
 }
@@ -87,7 +87,8 @@ static void dwarf_info_compile_unit(){
     print("\t.long .LASF0\n");  // DW_AT_comp_dir
     print("\t.quad .Ltext0\n"); // DW_AT_low_pc
     print("\t.quad .Letext0-.Ltext0\n"); // DW_AT_high_pc
-    print("\t.long .Ldebug_line0\n"); // DW_AT_stmt_list
+    print("\t.long 0\n"); // DW_AT_stmt_list
+    print("\t.byte 0x00\n"); // 0x00
 }
 
 // .debug_lineの出力

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -1,0 +1,64 @@
+#include "mcc2.h"
+#include "dwarf.h"
+
+static int g_asf = 0;           // .debug_str用のラベル
+static Dwarf_dstr* g_dstr;      // .debug_str用の文字列テーブル
+
+static void dwarf_abbrev();     // .debug_abbrev
+static void dwarf_info();       // .debug_info
+static void dwarf_str();        // .debug_str
+static void dwarf_line();       // .debug_line
+
+static void DWARF_Str(char* fmt, ...);
+
+void dwarf(){
+    dwarf_abbrev();
+    dwarf_info();
+    dwarf_line();
+    dwarf_str();
+}
+
+// .debug_abbrevの出力
+static void dwarf_abbrev(){
+
+}
+
+// .debug_infoの出力
+static void dwarf_info(){
+
+}
+
+// .debug_lineの出力
+static void dwarf_line(){
+    // セクション宣言とラベル
+    print("\t.section\t.debug_line, \"\",@progbits\n");
+    print(".Ldebug_line0:\n");
+}
+
+// .debug_strの出力
+static void dwarf_str(){
+    // セクション宣言
+    print("\t.section\t.debug_str, \"MS\",@progbits,1\n");
+
+}
+
+
+static void DWARF_Str(char* fmt, ...){
+    va_list ap;
+    va_start(ap, fmt);
+
+    int size = vsnprintf(NULL, 0, fmt, ap) + 1;
+    va_end(ap);
+
+    char* buf = calloc(size, sizeof(char));
+    va_start(ap, fmt);
+    vsnprintf(buf, size, fmt, ap);
+    va_end(ap);
+
+    Dwarf_dstr* dstr = calloc(1, sizeof(Dwarf_dstr));
+    dstr->id = g_asf;
+    dstr->str = buf;
+
+    print(".LASF%d:\n", g_asf++);
+    print("\t.string \"%s\"\n", buf);
+}

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -12,7 +12,7 @@ struct Dwarf_dstr {
     Dwarf_dstr* next;
 };
 
-#define DW_ATTR(X, Y)   do {print("\t.uleb128 0x%x\n", X); print("  .uleb128 0x%x\n", Y);} while(0)
+#define DW_ATTR(X, Y)   do {print("\t.uleb128 0x%x\n", X); print("\t.uleb128 0x%x\n", Y);} while(0)
 
 // attribute form encoding
 // attribute form encoding

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -11,3 +11,280 @@ struct Dwarf_dstr {
     char* str;
     Dwarf_dstr* next;
 };
+
+#define DW_ATTR(X, Y)   do {print("  .uleb128 0x%x\n", X); print("  .uleb128 0x%x\n", Y);} while(0)
+
+// attribute form encoding
+// attribute form encoding
+enum dwarf_form_encoding {
+    DW_FORM_addr            = 0x01,  // 0x01
+    /* 0x02 is reserved */
+    DW_FORM_block2          = 0x03,  // 0x03
+    DW_FORM_block4,                  // 0x04
+    DW_FORM_data2,                   // 0x05
+    DW_FORM_data4,                   // 0x06
+    DW_FORM_data8,                   // 0x07
+    DW_FORM_string,                  // 0x08
+    DW_FORM_block,                   // 0x09
+    DW_FORM_block1,                  // 0x0a
+    DW_FORM_data1,                   // 0x0b
+    DW_FORM_flag,                    // 0x0c
+    DW_FORM_sdata,                   // 0x0d
+    DW_FORM_strp,                    // 0x0e
+    DW_FORM_udata,                   // 0x0f
+    DW_FORM_ref_addr,                // 0x10
+    DW_FORM_ref1,                    // 0x11
+    DW_FORM_ref2,                    // 0x12
+    DW_FORM_ref4,                    // 0x13
+    DW_FORM_ref8,                    // 0x14
+    DW_FORM_ref_udata,               // 0x15
+    DW_FORM_indirect,                // 0x16
+    DW_FORM_sec_offset,              // 0x17
+    DW_FORM_exprloc,                 // 0x18
+    DW_FORM_flag_present,            // 0x19
+    DW_FORM_strx,                    // 0x1a
+    DW_FORM_addrx,                   // 0x1b
+    DW_FORM_ref_sup4,                // 0x1c
+    DW_FORM_strp_sup,                // 0x1d
+    DW_FORM_data16,                  // 0x1e
+    DW_FORM_line_strp,               // 0x1f
+    DW_FORM_ref_sig8,                // 0x20
+    DW_FORM_implicit_const,          // 0x21
+    DW_FORM_loclistx,                // 0x22
+    DW_FORM_rnglistx,                // 0x23
+    DW_FORM_ref_sup8,                // 0x24
+    DW_FORM_strx1,                   // 0x25
+    DW_FORM_strx2,                   // 0x26
+    DW_FORM_strx3,                   // 0x27
+    DW_FORM_strx4,                   // 0x28
+    DW_FORM_addrx1,                  // 0x29
+    DW_FORM_addrx2,                  // 0x2a
+    DW_FORM_addrx3,                  // 0x2b
+    DW_FORM_addrx4                   // 0x2c
+};
+
+// attribute encoding
+enum dwarf_attribute_encoding {
+    DW_AT_sibling           = 0x01,  // 0x01
+    DW_AT_location,                  // 0x02
+    DW_AT_name,                      // 0x03
+    // 0x04-0x08 reserved
+    DW_AT_ordering          = 0x09,  // 0x09
+    // 0x0A reserved
+    DW_AT_byte_size         = 0x0B,  // 0x0B
+    // 0x0C reserved
+    DW_AT_bit_size          = 0x0D,  // 0x0D
+    // 0x0E-0x0F reserved
+    DW_AT_stmt_list         = 0x10,  // 0x10
+    DW_AT_low_pc,                    // 0x11
+    DW_AT_high_pc,                   // 0x12
+    DW_AT_language,                  // 0x13
+    // 0x14 reserved
+    DW_AT_discr             = 0x15,  // 0x15
+    DW_AT_discr_value,               // 0x16
+    DW_AT_visibility,                // 0x17
+    DW_AT_import,                    // 0x18
+    DW_AT_string_length,             // 0x19
+    DW_AT_common_reference,          // 0x1A
+    DW_AT_comp_dir,                  // 0x1B
+    DW_AT_const_value,               // 0x1C
+    DW_AT_containing_type,           // 0x1D
+    DW_AT_default_value,             // 0x1E
+    // 0x1F reserved
+    DW_AT_inline            = 0x20,  // 0x20
+    DW_AT_is_optional,               // 0x21
+    DW_AT_lower_bound,               // 0x22
+    // 0x23-0x24 reserved
+    DW_AT_producer          = 0x25,  // 0x25
+    // 0x26 reserved
+    DW_AT_prototyped        = 0x27,  // 0x27
+    // 0x28-0x29 reserved
+    DW_AT_return_addr       = 0x2A,  // 0x2A
+    // 0x2B reserved
+    DW_AT_start_scope       = 0x2C,  // 0x2C
+    // 0x2D reserved
+    DW_AT_bit_stride        = 0x2E,  // 0x2E
+    DW_AT_upper_bound,               // 0x2F
+    // 0x30 reserved
+    DW_AT_abstract_origin   = 0x31,  // 0x31
+    DW_AT_accessibility,             // 0x32
+    DW_AT_address_class,             // 0x33
+    DW_AT_artificial,                // 0x34
+    DW_AT_base_types,                // 0x35
+    DW_AT_calling_convention,        // 0x36
+    DW_AT_count,                     // 0x37
+    DW_AT_data_member_location,      // 0x38
+    DW_AT_decl_column,               // 0x39
+    DW_AT_decl_file,                 // 0x3A
+    DW_AT_decl_line,                 // 0x3B
+    DW_AT_declaration,               // 0x3C
+    DW_AT_discr_list,                // 0x3D
+    DW_AT_encoding,                  // 0x3E
+    DW_AT_external,                  // 0x3F
+    DW_AT_frame_base,                // 0x40
+    DW_AT_friend,                    // 0x41
+    DW_AT_identifier_case,           // 0x42
+    // 0x43 reserved
+    DW_AT_namelist_item     = 0x44,  // 0x44
+    DW_AT_priority,                  // 0x45
+    DW_AT_segment,                   // 0x46
+    DW_AT_specification,             // 0x47
+    DW_AT_static_link,               // 0x48
+    DW_AT_type,                      // 0x49
+    DW_AT_use_location,              // 0x4A
+    DW_AT_variable_parameter,        // 0x4B
+    DW_AT_virtuality,                // 0x4C
+    DW_AT_vtable_elem_location,      // 0x4D
+    DW_AT_allocated,                 // 0x4E
+    DW_AT_associated,                // 0x4F
+    DW_AT_data_location,             // 0x50
+    DW_AT_byte_stride,               // 0x51
+    DW_AT_entry_pc,                  // 0x52
+    DW_AT_use_UTF8,                  // 0x53
+    DW_AT_extension,                 // 0x54
+    DW_AT_ranges,                    // 0x55
+    DW_AT_trampoline,                // 0x56
+    DW_AT_call_column,               // 0x57
+    DW_AT_call_file,                 // 0x58
+    DW_AT_call_line,                 // 0x59
+    DW_AT_description,               // 0x5A
+    DW_AT_binary_scale,              // 0x5B
+    DW_AT_decimal_scale,             // 0x5C
+    DW_AT_small,                     // 0x5D
+    DW_AT_decimal_sign,              // 0x5E
+    DW_AT_digit_count,               // 0x5F
+    DW_AT_picture_string,            // 0x60
+    DW_AT_mutable,                   // 0x61
+    DW_AT_threads_scaled,            // 0x62
+    DW_AT_explicit,                  // 0x63
+    DW_AT_object_pointer,            // 0x64
+    DW_AT_endianity,                 // 0x65
+    DW_AT_elemental,                 // 0x66
+    DW_AT_pure,                      // 0x67
+    DW_AT_recursive,                 // 0x68
+    DW_AT_signature,                 // 0x69
+    DW_AT_main_subprogram,           // 0x6A
+    DW_AT_data_bit_offset,           // 0x6B
+    DW_AT_const_expr,                // 0x6C
+    DW_AT_enum_class,                // 0x6D
+    DW_AT_linkage_name,              // 0x6E
+    DW_AT_string_length_bit_size,    // 0x6F
+    DW_AT_string_length_byte_size,   // 0x70
+    DW_AT_rank,                      // 0x71
+    DW_AT_str_offsets_base,          // 0x72
+    DW_AT_addr_base,                 // 0x73
+    DW_AT_rnglists_base,             // 0x74
+    // 0x75 reserved
+    DW_AT_dwo_name          = 0x76,  // 0x76
+    DW_AT_reference,                 // 0x77
+    DW_AT_rvalue_reference,          // 0x78
+    DW_AT_macros,                    // 0x79
+    DW_AT_call_all_calls,            // 0x7A
+    DW_AT_call_all_source_calls,     // 0x7B
+    DW_AT_call_all_tail_calls,       // 0x7C
+    DW_AT_call_return_pc,            // 0x7D
+    DW_AT_call_value,                // 0x7E
+    DW_AT_call_origin,               // 0x7F
+    DW_AT_call_parameter,            // 0x80
+    DW_AT_call_pc,                   // 0x81
+    DW_AT_call_tail_call,            // 0x82
+    DW_AT_call_target,               // 0x83
+    DW_AT_call_target_clobbered,     // 0x84
+    DW_AT_call_data_location,        // 0x85
+    DW_AT_call_data_value,           // 0x86
+    DW_AT_noreturn,                  // 0x87
+    DW_AT_alignment,                 // 0x88
+    DW_AT_export_symbols,            // 0x89
+    DW_AT_deleted,                   // 0x8A
+    DW_AT_defaulted,                 // 0x8B
+    DW_AT_loclists_base,             // 0x8C
+    // 0x8D-0x1FFF reserved
+    DW_AT_lo_user           = 0x2000,// 0x2000
+    DW_AT_hi_user           = 0x3FFF // 0x3FFF
+};
+
+// tag encoding
+#define DW_ABBREV_IDX()     print("  .uleb128 0x%x\n", g_abbrev_idx++)
+#define DW_ABBREV_TAG(X)    print("  .uleb128 0x%x\n", X);
+#define DW_CHILDREN_no()    print("  .byte 0x00\n")
+#define DW_CHILDREN_yes()   print("  .byte 0x01\n")
+
+enum dwarf_tag_encoding {
+    DW_TAG_array_type       = 0x01,  // 0x01
+    DW_TAG_class_type,               // 0x02
+    DW_TAG_entry_point,              // 0x03
+    DW_TAG_enumeration_type,         // 0x04
+    DW_TAG_formal_parameter,         // 0x05
+    // 0x06 - 0x07 reserved
+    DW_TAG_imported_declaration  = 0x08,  // 0x08
+    // 0x09 reserved
+    DW_TAG_label            = 0x0A,  // 0x0A
+    DW_TAG_lexical_block,            // 0x0B
+    // 0x0C reserved
+    DW_TAG_member           = 0x0D,  // 0x0D
+    // 0x0E reserved
+    DW_TAG_pointer_type     = 0x0F,  // 0x0F
+    DW_TAG_reference_type,           // 0x10
+    DW_TAG_compile_unit,             // 0x11
+    DW_TAG_string_type,              // 0x12
+    DW_TAG_structure_type,           // 0x13
+    // 0x14 reserved
+    DW_TAG_subroutine_type   = 0x15,  // 0x15
+    DW_TAG_typedef          = 0x16,  // 0x16
+    DW_TAG_union_type,               // 0x17
+    DW_TAG_unspecified_parameters,   // 0x18
+    DW_TAG_variant,                  // 0x19
+    DW_TAG_common_block,             // 0x1A
+    DW_TAG_common_inclusion,         // 0x1B
+    DW_TAG_inheritance,              // 0x1C
+    DW_TAG_inlined_subroutine,       // 0x1D
+    DW_TAG_module,                   // 0x1E
+    DW_TAG_ptr_to_member_type,       // 0x1F
+    DW_TAG_set_type,                 // 0x20
+    DW_TAG_subrange_type,            // 0x21
+    DW_TAG_with_stmt,                // 0x22
+    DW_TAG_access_declaration,       // 0x23
+    DW_TAG_base_type,                // 0x24
+    DW_TAG_catch_block,              // 0x25
+    DW_TAG_const_type,               // 0x26
+    DW_TAG_constant,                 // 0x27
+    DW_TAG_enumerator,               // 0x28
+    DW_TAG_file_type,                // 0x29
+    DW_TAG_friend,                   // 0x2A
+    DW_TAG_namelist,                 // 0x2B
+    DW_TAG_namelist_item,            // 0x2C
+    DW_TAG_packed_type,              // 0x2D
+    DW_TAG_subprogram,               // 0x2E
+    DW_TAG_template_type_parameter,  // 0x2F
+    DW_TAG_template_value_parameter, // 0x30
+    DW_TAG_thrown_type,              // 0x31
+    DW_TAG_try_block,                // 0x32
+    DW_TAG_variant_part,             // 0x33
+    DW_TAG_variable,                 // 0x34
+    DW_TAG_volatile_type,            // 0x35
+    DW_TAG_dwarf_procedure,          // 0x36
+    DW_TAG_restrict_type,            // 0x37
+    DW_TAG_interface_type,           // 0x38
+    DW_TAG_namespace,                // 0x39
+    DW_TAG_imported_module,          // 0x3A
+    DW_TAG_unspecified_type,         // 0x3B
+    DW_TAG_partial_unit,             // 0x3C
+    DW_TAG_imported_unit,            // 0x3D
+    // 0x3E reserved
+    DW_TAG_condition,                // 0x3F
+    DW_TAG_shared_type,              // 0x40
+    DW_TAG_type_unit,                // 0x41
+    DW_TAG_rvalue_reference_type,    // 0x42
+    DW_TAG_template_alias,           // 0x43
+    DW_TAG_coarray_type,             // 0x44
+    DW_TAG_generic_subrange,         // 0x45
+    DW_TAG_dynamic_type,             // 0x46
+    DW_TAG_atomic_type,              // 0x47
+    DW_TAG_call_site,                // 0x48
+    DW_TAG_call_site_parameter,      // 0x49
+    DW_TAG_skeleton_unit,            // 0x4A
+    DW_TAG_immutable_type,           // 0x4B
+    DW_TAG_lo_user           = 0x4080,// 0x4080
+    DW_TAG_hi_user           = 0xFFFF // 0xFFFF
+};
+

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -12,7 +12,7 @@ struct Dwarf_dstr {
     Dwarf_dstr* next;
 };
 
-#define DW_ATTR(X, Y)   do {print("  .uleb128 0x%x\n", X); print("  .uleb128 0x%x\n", Y);} while(0)
+#define DW_ATTR(X, Y)   do {print("\t.uleb128 0x%x\n", X); print("  .uleb128 0x%x\n", Y);} while(0)
 
 // attribute form encoding
 // attribute form encoding
@@ -204,10 +204,10 @@ enum dwarf_attribute_encoding {
 };
 
 // tag encoding
-#define DW_ABBREV_IDX()     print("  .uleb128 0x%x\n", g_abbrev_idx++)
-#define DW_ABBREV_TAG(X)    print("  .uleb128 0x%x\n", X);
-#define DW_CHILDREN_no()    print("  .byte 0x00\n")
-#define DW_CHILDREN_yes()   print("  .byte 0x01\n")
+#define DW_ABBREV_IDX()     print("\t.uleb128 0x%x\n", g_abbrev_idx++)
+#define DW_ABBREV_TAG(X)    print("\t.uleb128 0x%x\n", X);
+#define DW_CHILDREN_no()    print("\t.byte 0x00\n")
+#define DW_CHILDREN_yes()   print("\t.byte 0x01\n")
 
 enum dwarf_tag_encoding {
     DW_TAG_array_type       = 0x01,  // 0x01

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// DWARF directives
+
+
+typedef struct Dwarf_dstr Dwarf_dstr;
+
+// debug_string table
+struct Dwarf_dstr {
+    int id;
+    char* str;
+    Dwarf_dstr* next;
+};

--- a/src/gen_ir.c
+++ b/src/gen_ir.c
@@ -37,7 +37,6 @@ void gen_ir(){
     // .fileを出力する
     IR head;
     ir = &head;
-    new_IR(IR_FILE_SECTION, NULL, new_RegStr(main_file->name), NULL);
     scope->ir_cmd = head.next;
 
     Ident* ident;

--- a/src/gen_x86_64.c
+++ b/src/gen_x86_64.c
@@ -410,7 +410,7 @@ void gen_x86(){
     Scope* global_scope = get_global_scope();
 
     print("\t.intel_syntax noprefix\n");
-    print("\t.file \"%s\"\n", main_file->name);
+    print("\t.file \"%s\"\n", cinfo.compile_file->path);
     set_section(TEXT);
     print(".Ltext0:\n");
 
@@ -473,7 +473,7 @@ static void convert_ir2x86asm(IR* ir){
                     if(!func->tok->file->labeled){
                         func->tok->file->labeled = 1;
                         func->tok->file->label = file_label++;
-                        print("\t.file %d \"%s\"\n", func->tok->file->label, func->tok->file->name);
+                        print("\t.file %d \"%s\"\n", func->tok->file->label, func->tok->file->path);
                     }
                     print("\t.loc %d %d %d\n", func->tok->file->label,
                                                 func->tok->row, func->tok->col);

--- a/src/gen_x86_64.c
+++ b/src/gen_x86_64.c
@@ -587,6 +587,9 @@ static void convert_ir2x86asm(IR* ir){
                         // 初期化あり
                         print("\t.globl\t%s\n", ident->name);
                         set_section(DATA);
+                        print("\t.align %d\n", get_qtype_align(ident->qtype));
+                        print("\t.type\t%s, @object\n", ident->name);
+                        print("\t.size\t%s, %d\n", ident->name, ir->s2->val);
                         print("%s:\n", ir->s1->ident->name);
                         if(!(ident->reloc->label)){
                             switch(ident->reloc->size){

--- a/src/gen_x86_64.c
+++ b/src/gen_x86_64.c
@@ -410,7 +410,7 @@ void gen_x86(){
     Scope* global_scope = get_global_scope();
 
     print("\t.intel_syntax noprefix\n");
-    print("\t.file \"%s\"\n", cinfo.compile_file);
+    print("\t.file \"%s\"\n", main_file->name);
     set_section(TEXT);
     print(".Ltext0:\n");
 
@@ -447,7 +447,7 @@ void gen_x86(){
         }
         ident = ident->next;
     }
-
+    set_section(TEXT);
     print(".Letext0:\n");
 }
 
@@ -473,7 +473,7 @@ static void convert_ir2x86asm(IR* ir){
                     if(!func->tok->file->labeled){
                         func->tok->file->labeled = 1;
                         func->tok->file->label = file_label++;
-                        print("\t.file %d \"%s\"\n", func->tok->file->label, func->tok->file->path);
+                        print("\t.file %d \"%s\"\n", func->tok->file->label, func->tok->file->name);
                     }
                     print("\t.loc %d %d %d\n", func->tok->file->label,
                                                 func->tok->row, func->tok->col);

--- a/src/gen_x86_64.c
+++ b/src/gen_x86_64.c
@@ -37,13 +37,13 @@ static void set_section(SECTION set){
     }
     switch(set){
         case TEXT:
-            print("  .text\n");
+            print("\t.text\n");
             break;
         case DATA:
-            print("  .data\n");
+            print("\t.data\n");
             break;
         case BSS:
-            print("  .bss\n");
+            print("\t.bss\n");
             break;
         default:
             break;
@@ -131,14 +131,14 @@ static int get_regno(char* reg){
 }
 
 static void pop(char* reg){
-    print("  pop %s\n", reg);
+    print("\tpop %s\n", reg);
     --depth;
 
     int idx = get_regno(reg);
 }
 
 static void push(char* reg){
-    print("  push %s\n", reg);
+    print("\tpush %s\n", reg);
     ++depth;
     int idx = get_regno(reg);
 }
@@ -187,7 +187,7 @@ static int findReg(){
         print("# spill %s to [rbp - %d]\n", rreg64[src_reg_idx], 8 * spill_idx);
     }
 
-    print("  mov QWORD PTR [rbp - 240 + %d], %s\n", 8 * spill_idx, rreg64[src_reg_idx]);
+    print("\tmov QWORD PTR [rbp - 240 + %d], %s\n", 8 * spill_idx, rreg64[src_reg_idx]);
     spillReg[spill_idx] = 1;
     realReg[src_reg_idx]->spill_idx = spill_idx;
 
@@ -222,7 +222,7 @@ static void activateReg(Reg* reg, int is_lhs){
             print("# back from spill [rbp - %d] to %s\n", 8 * reg->spill_idx, rreg64[reg->idx]);
         }
 
-        print("  mov %s, QWORD PTR [rbp - 240 + %d]\n", rreg64[reg->idx], 8 * reg->spill_idx);
+        print("\tmov %s, QWORD PTR [rbp - 240 + %d]\n", rreg64[reg->idx], 8 * reg->spill_idx);
         spillReg[reg->spill_idx] = 0;
         reg->spill_idx = -1;
         return;
@@ -234,7 +234,7 @@ static void activateReg(Reg* reg, int is_lhs){
         case REG_IMM:
             if(is_lhs){
                 assignReg(reg);
-                print("  mov %s, %lu\n", reg->rreg, reg->val);
+                print("\tmov %s, %lu\n", reg->rreg, reg->val);
             } else {
                 reg->rreg = format_string("%lu\0", reg->val);
             }
@@ -250,32 +250,32 @@ static void activateReg(Reg* reg, int is_lhs){
 
                 if(ident->kind == ID_LVAR){
                     if(size == 1){
-                        print("  movsx %s, BYTE PTR[rbp - %d]\n", reg->rreg, ident->offset);
+                        print("\tmovsx %s, BYTE PTR[rbp - %d]\n", reg->rreg, ident->offset);
                     } else if(size == 2){
-                        print("  movsx %s, WORD PTR[rbp - %d]\n", reg->rreg, ident->offset);
+                        print("\tmovsx %s, WORD PTR[rbp - %d]\n", reg->rreg, ident->offset);
                     } else if(size == 8){
-                        print("  mov %s, QWORD PTR[rbp - %d]\n", reg->rreg, ident->offset);
+                        print("\tmov %s, QWORD PTR[rbp - %d]\n", reg->rreg, ident->offset);
                     }
                 } else if(ident->kind == ID_GVAR){
                     if(ident->is_static){
                         if(size == 1){
-                            print("  movsx %s, BYTE PTR[.L%s]\n", reg->rreg, ident->name);
+                            print("\tmovsx %s, BYTE PTR[.L%s]\n", reg->rreg, ident->name);
                         } else if(size == 2){
-                            print("  movsx %s, WORD PTR[.L%s]\n", reg->rreg, ident->name);
+                            print("\tmovsx %s, WORD PTR[.L%s]\n", reg->rreg, ident->name);
                         } else if(size == 8){
-                            print("  mov %s, QWORD PTR[.L%s]\n", reg->rreg, ident->name);
+                            print("\tmov %s, QWORD PTR[.L%s]\n", reg->rreg, ident->name);
                         }
                     } else {
                         if(size == 1){
-                            print("  movsx %s, BYTE PTR[%s]\n", reg->rreg, ident->name);
+                            print("\tmovsx %s, BYTE PTR[%s]\n", reg->rreg, ident->name);
                         } else if(size == 2){
-                            print("  movsx %s, WORD PTR[%s]\n", reg->rreg, ident->name);
+                            print("\tmovsx %s, WORD PTR[%s]\n", reg->rreg, ident->name);
                         } else if(size == 8){
-                            print("  mov %s, QWORD PTR[%s]\n", reg->rreg, ident->name);
+                            print("\tmov %s, QWORD PTR[%s]\n", reg->rreg, ident->name);
                         }
                     }
                 }  else if(ident->kind == ID_GVAR && ident->is_string_literal){
-                    print("  lea %s, [ rip + %s ]\n", reg->rreg, ident->name);
+                    print("\tlea %s, [ rip + %s ]\n", reg->rreg, ident->name);
                 }
             }
             break;
@@ -319,7 +319,7 @@ static void freeRegAllForce(){
 static void emit_binop(char* op, Reg* t, Reg* s1, Reg* s2){
     activateRegLhs(s1);
     activateRegRhs(s2);
-    print("  %s %s, %s\n", op, s1->rreg, s2->rreg);
+    print("\t%s %s, %s\n", op, s1->rreg, s2->rreg);
 
     if(t){
         // あるならそっちにmovが入る
@@ -362,43 +362,43 @@ static void gen_cast_x86(Reg* t, Reg* s1, CAST_CMD cmd){
 
     switch(cmd){
         case NO_NEED:
-            print("  mov %s, %s\n", t->rreg, s1->rreg);
+            print("\tmov %s, %s\n", t->rreg, s1->rreg);
             break;
         case i64_i8:
-            print("  movsx %s, %s\n", t->rreg, rreg8[s1->idx]);
+            print("\tmovsx %s, %s\n", t->rreg, rreg8[s1->idx]);
             break;
         case i64_i16:
-            print("  movsx %s, %s\n", t->rreg, rreg16[s1->idx]);
+            print("\tmovsx %s, %s\n", t->rreg, rreg16[s1->idx]);
             break;
         case i64_i32:
-            print("  movsxd %s, %s\n", t->rreg, rreg32[s1->idx]);
+            print("\tmovsxd %s, %s\n", t->rreg, rreg32[s1->idx]);
             break;
         case u64_i8:
-            print("  movzx %s, %s\n", t->rreg, rreg8[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg8[s1->idx]);
             break;
         case u64_i16:
-            print("  movzx %s, %s\n", t->rreg, rreg16[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg16[s1->idx]);
             break;
         case u64_i32:
-            print("  mov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
+            print("\tmov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
             break;
         case i64_u8:
-            print("  movzx %s, %s\n", t->rreg, rreg8[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg8[s1->idx]);
             break;
         case i64_u16:
-            print("  movzx %s, %s\n", t->rreg, rreg16[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg16[s1->idx]);
             break;
         case i64_u32:
-            print("  mov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
+            print("\tmov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
             break;
         case u64_u8:
-            print("  movzx %s, %s\n", t->rreg, rreg8[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg8[s1->idx]);
             break;
         case u64_u16:
-            print("  movzx %s, %s\n", t->rreg, rreg16[s1->idx]);
+            print("\tmovzx %s, %s\n", t->rreg, rreg16[s1->idx]);
             break;
         case u64_u32:
-            print("  mov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
+            print("\tmov %s, %s\n", rreg32[t->idx], rreg32[s1->idx]);
             break;
         default:
             error("invalid cast %d \n", cmd);
@@ -479,8 +479,8 @@ static void convert_ir2x86asm(IR* ir){
                                                 func->tok->row, func->tok->col);
                 }
                 push("rbp");
-                print("  mov rbp, rsp\n");
-                print("  sub rsp, %d\n", ((ir->s2->val + 15) / 16) * 16);
+                print("\tmov rbp, rsp\n");
+                print("\tsub rsp, %d\n", ((ir->s2->val + 15) / 16) * 16);
                 push("r12");
                 push("r13");
                 push("r14");
@@ -495,9 +495,9 @@ static void convert_ir2x86asm(IR* ir){
                 pop("r14");
                 pop("r13");
                 pop("r12");
-                print("  mov rsp, rbp\n");
+                print("\tmov rsp, rbp\n");
                 pop("rbp");
-                print("  ret\n");
+                print("\tret\n");
                 print(".LFE%d:\n", func->func_id);
                 print("\t.size %s, .-%s\n", func->name, func->name);
                 break;
@@ -509,34 +509,34 @@ static void convert_ir2x86asm(IR* ir){
                 int fp = ir->s2->val;
 
                 // 引数の退避
-                print("  mov QWORD PTR [rbp - 176], rdi\n");
-                print("  mov QWORD PTR [rbp - 168], rsi\n");
-                print("  mov QWORD PTR [rbp - 160], rdx\n");
-                print("  mov QWORD PTR [rbp - 152], rcx\n");
-                print("  mov QWORD PTR [rbp - 144], r8\n");
-                print("  mov QWORD PTR [rbp - 136], r9\n");
-                print("  test al, al\n");
-                print("  je .L%d\n", label);
-                print("  movaps XMMWORD PTR [rbp - 128], xmm0\n");
-                print("  movaps XMMWORD PTR [rbp - 112], xmm1\n");
-                print("  movaps XMMWORD PTR [rbp - 96], xmm2\n");
-                print("  movaps XMMWORD PTR [rbp - 80], xmm3\n");
-                print("  movaps XMMWORD PTR [rbp - 64], xmm4\n");
-                print("  movaps XMMWORD PTR [rbp - 48], xmm5\n");
-                print("  movaps XMMWORD PTR [rbp - 32], xmm6\n");
-                print("  movaps XMMWORD PTR [rbp - 16], xmm7\n");
+                print("\tmov QWORD PTR [rbp - 176], rdi\n");
+                print("\tmov QWORD PTR [rbp - 168], rsi\n");
+                print("\tmov QWORD PTR [rbp - 160], rdx\n");
+                print("\tmov QWORD PTR [rbp - 152], rcx\n");
+                print("\tmov QWORD PTR [rbp - 144], r8\n");
+                print("\tmov QWORD PTR [rbp - 136], r9\n");
+                print("\ttest al, al\n");
+                print("\tje .L%d\n", label);
+                print("\tmovaps XMMWORD PTR [rbp - 128], xmm0\n");
+                print("\tmovaps XMMWORD PTR [rbp - 112], xmm1\n");
+                print("\tmovaps XMMWORD PTR [rbp - 96], xmm2\n");
+                print("\tmovaps XMMWORD PTR [rbp - 80], xmm3\n");
+                print("\tmovaps XMMWORD PTR [rbp - 64], xmm4\n");
+                print("\tmovaps XMMWORD PTR [rbp - 48], xmm5\n");
+                print("\tmovaps XMMWORD PTR [rbp - 32], xmm6\n");
+                print("\tmovaps XMMWORD PTR [rbp - 16], xmm7\n");
                 print(".L%d:\n", label);
             }
                 break;
             case IR_VA_START:
             {
                 activateRegLhs(ir->s1);
-                print("  mov DWORD PTR [%s + 0], %d\n", ir->s1->rreg, 8 * ir->s2->val);
-                print("  mov DWORD PTR [%s + 4], %d\n", ir->s1->rreg, 48);
-                print("  lea rax, [rbp + 16]\n");
-                print("  mov QWORD PTR [%s + 8], rax\n", ir->s1->rreg);
-                print("  lea rax, [rbp - 176]\n");
-                print("  mov QWORD PTR [%s + 16], rax\n", ir->s1->rreg);
+                print("\tmov DWORD PTR [%s + 0], %d\n", ir->s1->rreg, 8 * ir->s2->val);
+                print("\tmov DWORD PTR [%s + 4], %d\n", ir->s1->rreg, 48);
+                print("\tlea rax, [rbp + 16]\n");
+                print("\tmov QWORD PTR [%s + 8], rax\n", ir->s1->rreg);
+                print("\tlea rax, [rbp - 176]\n");
+                print("\tmov QWORD PTR [%s + 16], rax\n", ir->s1->rreg);
                 break;
             }
             case IR_EXTERN_LABEL:
@@ -546,30 +546,30 @@ static void convert_ir2x86asm(IR* ir){
             {
                 int size = get_qtype_size(ir->s1->ident->qtype);
                 if(size == 1){
-                    print("  mov [rbp - %d], %s\n", ir->s1->ident->offset, argreg8[ir->s2->val]);
+                    print("\tmov [rbp - %d], %s\n", ir->s1->ident->offset, argreg8[ir->s2->val]);
                 } else if(size == 2){
-                    print("  mov [rbp - %d], %s\n", ir->s1->ident->offset, argreg16[ir->s2->val]);
+                    print("\tmov [rbp - %d], %s\n", ir->s1->ident->offset, argreg16[ir->s2->val]);
                 } else if(size == 4){
-                    print("  mov [rbp - %d], %s\n", ir->s1->ident->offset, argreg32[ir->s2->val]);
+                    print("\tmov [rbp - %d], %s\n", ir->s1->ident->offset, argreg32[ir->s2->val]);
                 } else if(size == 8){
-                    print("  mov [rbp - %d], %s\n", ir->s1->ident->offset, argreg64[ir->s2->val]);
+                    print("\tmov [rbp - %d], %s\n", ir->s1->ident->offset, argreg64[ir->s2->val]);
                 }
                 break;
             }
             case IR_LOAD_ARG_REG:
                 activateRegLhs(ir->s1);
-                print("  mov %s, %s\n", argreg64[ir->t->val], ir->s1->rreg);
+                print("\tmov %s, %s\n", argreg64[ir->t->val], ir->s1->rreg);
                 freeReg(ir->s1);
                 break;
             case IR_SET_FLOAT_NUM:
-                print("  mov eax, %d\n", '\0');
+                print("\tmov eax, %d\n", '\0');
                 break;
             case IR_RET:
                 if(ir->s1){
                     activateRegLhs(ir->s1);
-                    print("  mov rax, %s\n", ir->s1->rreg);
+                    print("\tmov rax, %s\n", ir->s1->rreg);
                 }
-                print("  jmp ret_%s\n", ir->s2->ident->name);
+                print("\tjmp ret_%s\n", ir->s2->ident->name);
                 break;
             case IR_GVAR_LABEL:
             {
@@ -577,11 +577,11 @@ static void convert_ir2x86asm(IR* ir){
                 if(ident->is_string_literal){
                     set_section(DATA);
                     print("%s:\n", ident->name);
-                    print("  .string \"%s\"\n", get_token_string_literal(ident->tok));
+                    print("\t.string \"%s\"\n", get_token_string_literal(ident->tok));
                 } else if(ident->is_static) {
                     set_section(BSS);
                     print(".L%s:\n", ir->s1->ident->name);
-                    print("  .zero %d\n", ir->s2->val);
+                    print("\t.zero %d\n", ir->s2->val);
                 } else {
                     if(ident->reloc){
                         // 初期化あり
@@ -591,20 +591,20 @@ static void convert_ir2x86asm(IR* ir){
                         if(!(ident->reloc->label)){
                             switch(ident->reloc->size){
                                 case 1:
-                                    print("  .byte %d\n", ident->reloc->data);
+                                    print("\t.byte %d\n", ident->reloc->data);
                                     break;
                                 case 2:
-                                    print("  .value %d\n", ident->reloc->data);
+                                    print("\t.value %d\n", ident->reloc->data);
                                     break;
                                 case 4:
-                                    print("  .long %d\n", ident->reloc->data);
+                                    print("\t.long %d\n", ident->reloc->data);
                                     break;
                                 case 8:
-                                    print("  .quad %d\n", ident->reloc->data);
+                                    print("\t.quad %d\n", ident->reloc->data);
                                     break;
                             }
                         } else {
-                            print("  .quad %s\n", ident->reloc->label);
+                            print("\t.quad %s\n", ident->reloc->label);
                         }
                     } else {
                         print("\t.globl\t%s\n", ident->name);
@@ -612,7 +612,7 @@ static void convert_ir2x86asm(IR* ir){
                         print("\t.type\t%s, @object\n", ident->name);
                         print("\t.size\t%s, %d\n", ident->name, ir->s2->val);
                         print("%s:\n", ir->s1->ident->name);
-                        print("  .zero %d\n", ir->s2->val);
+                        print("\t.zero %d\n", ir->s2->val);
                     }
                 }
                 break;
@@ -632,10 +632,10 @@ static void convert_ir2x86asm(IR* ir){
                 // idivが受け取るoperandはレジスタなので、
                 // 左辺値として割り当てる
                 activateRegLhs(ir->s2);
-                print("  mov rax, %s\n", ir->s1->rreg);
-                print("  cqo\n");
-                print("  idiv %s\n", ir->s2->rreg);
-                print("  mov %s, rax\n", ir->s1->rreg);
+                print("\tmov rax, %s\n", ir->s1->rreg);
+                print("\tcqo\n");
+                print("\tidiv %s\n", ir->s2->rreg);
+                print("\tmov %s, rax\n", ir->s1->rreg);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_MOD:
@@ -644,10 +644,10 @@ static void convert_ir2x86asm(IR* ir){
                 // idivが受け取るoperandはレジスタなので、
                 // 左辺値として割り当てる
                 activateRegLhs(ir->s2);
-                print("  mov rax, %s\n", ir->s1->rreg);
-                print("  cqo\n");
-                print("  idiv %s\n", ir->s2->rreg);
-                print("  mov %s, rdx\n", ir->s1->rreg);
+                print("\tmov rax, %s\n", ir->s1->rreg);
+                print("\tcqo\n");
+                print("\tidiv %s\n", ir->s2->rreg);
+                print("\tmov %s, rdx\n", ir->s1->rreg);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_EQUAL:
@@ -657,27 +657,27 @@ static void convert_ir2x86asm(IR* ir){
                 // cmp命令は直値は32bit幅までしか受け取れないので、
                 // 左辺値として割り当てる
                 activateRegLhs(ir->s2);
-                print("  cmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
-                print("  sete al\n");
-                print("  movzb %s, al\n", ir->t->rreg);
+                print("\tcmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tsete al\n");
+                print("\tmovzb %s, al\n", ir->t->rreg);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_NOT_EQUAL:
                 activateRegLhs(ir->t);
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  cmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
-                print("  setne al\n");
-                print("  movzb %s, al\n", ir->t->rreg);
+                print("\tcmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tsetne al\n");
+                print("\tmovzb %s, al\n", ir->t->rreg);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_LT:
                 activateRegLhs(ir->t);
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  cmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
-                print("  setl al\n");
-                print("  movzb %s, al\n", ir->t->rreg);
+                print("\tcmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tsetl al\n");
+                print("\tmovzb %s, al\n", ir->t->rreg);
                 freeReg(ir->s1);
                 freeReg(ir->s2);
                 break;
@@ -685,9 +685,9 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegLhs(ir->t);
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  cmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
-                print("  setle al\n");
-                print("  movzb %s, al\n", ir->t->rreg);
+                print("\tcmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tsetle al\n");
+                print("\tmovzb %s, al\n", ir->t->rreg);
                 freeReg(ir->s1);
                 freeReg(ir->s2);
                 break;
@@ -704,10 +704,10 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
                 if(ir->s2->kind == REG_IMM){
-                    print("  sal %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                    print("\tsal %s, %s\n", ir->s1->rreg, ir->s2->rreg);
                 } else {
-                    print("  mov rcx, %s\n", ir->s2->rreg);
-                    print("  sal %s, cl\n", ir->s1->rreg);
+                    print("\tmov rcx, %s\n", ir->s2->rreg);
+                    print("\tsal %s, cl\n", ir->s1->rreg);
                 }
                 if(ir->s2->kind == REG_IMM){
                     freeRegAll(ir->t, ir->s1, ir->s2);
@@ -717,10 +717,10 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
                 if(ir->s2->kind == REG_IMM){
-                    print("  sar %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                    print("\tsar %s, %s\n", ir->s1->rreg, ir->s2->rreg);
                 } else {
-                    print("  mov rcx, %s\n", ir->s2->rreg);
-                    print("  sar %s, cl\n", ir->s1->rreg);
+                    print("\tmov rcx, %s\n", ir->s2->rreg);
+                    print("\tsar %s, cl\n", ir->s1->rreg);
                 }
                 if(ir->s2->kind == REG_IMM){
                     freeRegAll(ir->t, ir->s1, ir->s2);
@@ -730,18 +730,18 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegLhs(ir->s1);
                 activateRegLhs(ir->s2);
                 if(ir->s1->size == 1){
-                    print("  mov [%s], %s\n", ir->s1->rreg, rreg8[ir->s2->idx]);
+                    print("\tmov [%s], %s\n", ir->s1->rreg, rreg8[ir->s2->idx]);
                 } else if(ir->s1->size == 2){
-                    print("  mov [%s], %s\n", ir->s1->rreg, rreg16[ir->s2->idx]);
+                    print("\tmov [%s], %s\n", ir->s1->rreg, rreg16[ir->s2->idx]);
                 } else if(ir->s1->size == 4){
-                    print("  mov [%s], %s\n", ir->s1->rreg, rreg32[ir->s2->idx]);
+                    print("\tmov [%s], %s\n", ir->s1->rreg, rreg32[ir->s2->idx]);
                 } else if(ir->s1->size == 8){
-                    print("  mov [%s], %s\n", ir->s1->rreg, rreg64[ir->s2->idx]);
+                    print("\tmov [%s], %s\n", ir->s1->rreg, rreg64[ir->s2->idx]);
                 }
 
                 if(ir->t){
                     activateRegLhs(ir->t);
-                    print("  mov %s, %s\n", ir->t->rreg, ir->s2->rreg);
+                    print("\tmov %s, %s\n", ir->t->rreg, ir->s2->rreg);
                 }
                 freeReg(ir->s2);
                 freeReg(ir->s1);
@@ -749,25 +749,25 @@ static void convert_ir2x86asm(IR* ir){
             case IR_FN_CALL:
                 {
                     if(depth % 2){
-                        print("  sub rsp, 8\n");
+                        print("\tsub rsp, 8\n");
                     }
-                    print("  call %s\n", ir->s1->ident->name);
+                    print("\tcall %s\n", ir->s1->ident->name);
                     if(depth % 2){
-                        print("  add rsp, 8\n");
+                        print("\tadd rsp, 8\n");
                     }
                     activateRegLhs(ir->t);
-                    print("  mov %s, rax\n", ir->t->rreg);
+                    print("\tmov %s, rax\n", ir->t->rreg);
                 }
                 break;
             case IR_REL:
                 activateRegLhs(ir->t);
                 if(ir->s1->ident->kind == ID_LVAR){
-                    print("  lea %s, [rbp - %d]\n", ir->t->rreg, ir->s1->ident->offset);
+                    print("\tlea %s, [rbp - %d]\n", ir->t->rreg, ir->s1->ident->offset);
                 } else if(ir->s1->ident->kind == ID_GVAR){
                     if(ir->s1->ident->is_static){
-                        print("  lea %s, [ rip + .L%s ]\n", ir->t->rreg, ir->s1->ident->name);
+                        print("\tlea %s, [ rip + .L%s ]\n", ir->t->rreg, ir->s1->ident->name);
                     } else {
-                        print("  lea %s, [ rip + %s ]\n", ir->t->rreg, ir->s1->ident->name);
+                        print("\tlea %s, [ rip + %s ]\n", ir->t->rreg, ir->s1->ident->name);
                     }
                 }
                 break;
@@ -787,7 +787,7 @@ static void convert_ir2x86asm(IR* ir){
             case IR_MOV:
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  mov %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tmov %s, %s\n", ir->s1->rreg, ir->s2->rreg);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_COPY:
@@ -796,10 +796,10 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegLhs(ir->s1);
                 for(int i = 0; i < ir->s1->size; i++){
                     // r8bレジスタにbyteデータコピー
-                    print("  mov r8b, BYTE PTR [%s + %d]\n", ir->s1->rreg, i);
+                    print("\tmov r8b, BYTE PTR [%s + %d]\n", ir->s1->rreg, i);
 
                     // r8bレジスタのデータをtのレジスタにコピー
-                    print("  mov BYTE PTR [%s + %d], r8b\n", ir->t->rreg, i);
+                    print("\tmov BYTE PTR [%s + %d], r8b\n", ir->t->rreg, i);
                 }
                 freeReg(ir->s1);
             }
@@ -815,31 +815,31 @@ static void convert_ir2x86asm(IR* ir){
             case IR_JNZ:
                 activateRegLhs(ir->s1);
                 //activateRegRhs(ir->s2);
-                print("  cmp %s, 0\n", ir->s1->rreg);
-                print("  jne .L%d\n", ir->s2->val);
+                print("\tcmp %s, 0\n", ir->s1->rreg);
+                print("\tjne .L%d\n", ir->s2->val);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_JZ:
                 activateRegLhs(ir->s1);
                 //activateRegRhs(ir->s2);
-                print("  cmp %s, 0\n", ir->s1->rreg);
-                print("  je .L%d\n", ir->s2->val);
+                print("\tcmp %s, 0\n", ir->s1->rreg);
+                print("\tje .L%d\n", ir->s2->val);
                 freeRegAll(ir->t, ir->s1, ir->s2);
                 break;
             case IR_JE:
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  cmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
-                print("  je .L%d\n", ir->t->val);
+                print("\tcmp %s, %s\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tje .L%d\n", ir->t->val);
                 freeReg(ir->s2);
                 break;
             case IR_JMP:
-                print("  jmp .L%d\n", ir->s1->val);
+                print("\tjmp .L%d\n", ir->s1->val);
                 break;
             case IR_LEA:
                 activateRegLhs(ir->s1);
                 activateRegRhs(ir->s2);
-                print("  lea %s, [rbp - %s]\n", ir->s1->rreg, ir->s2->rreg);
+                print("\tlea %s, [rbp - %s]\n", ir->s1->rreg, ir->s2->rreg);
                 freeReg(ir->s2);
                 break;
             case IR_LOAD:
@@ -847,23 +847,23 @@ static void convert_ir2x86asm(IR* ir){
                 activateRegRhs(ir->s2);
                 if(ir->s2->is_unsigned){
                     if(ir->s2->size == 1){
-                        print("  movzx %s, BYTE PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmovzx %s, BYTE PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     } else if(ir->s2->size == 2){
-                        print("  movzx %s, WORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmovzx %s, WORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     } else if(ir->s2->size == 4){
-                        print("  mov %s, DWORD PTR [%s]\n", rreg32[ir->s1->idx], ir->s2->rreg);
+                        print("\tmov %s, DWORD PTR [%s]\n", rreg32[ir->s1->idx], ir->s2->rreg);
                     } else if(ir->s2->size == 8){
-                        print("  mov %s, QWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmov %s, QWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     }
                 } else {
                     if(ir->s2->size == 1){
-                        print("  movsx %s, BYTE PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmovsx %s, BYTE PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     } else if(ir->s2->size == 2){
-                        print("  movsx %s, WORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmovsx %s, WORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     } else if(ir->s2->size == 4){
-                        print("  movsxd %s, DWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmovsxd %s, DWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     } else if(ir->s2->size == 8){
-                        print("  mov %s, QWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
+                        print("\tmov %s, QWORD PTR [%s]\n", ir->s1->rreg, ir->s2->rreg);
                     }
                 }
                 freeReg(ir->s2);

--- a/src/gen_x86_64.c
+++ b/src/gen_x86_64.c
@@ -459,7 +459,7 @@ static void convert_ir2x86asm(IR* ir){
             {
                 Ident* func = ir->s1->ident;
                 set_section(TEXT);
-                print("\t.global %s\n", func->name);
+                print("\t.globl %s\n", func->name);
                 print("\t.type	%s, @function\n", func->name);
                 print("%s:\n", func->name);
 
@@ -540,7 +540,7 @@ static void convert_ir2x86asm(IR* ir){
                 break;
             }
             case IR_EXTERN_LABEL:
-                print(".global %s\n", ir->s1->str);
+                print(".globl %s\n", ir->s1->str);
                 break;
             case IR_STORE_ARG_REG:
             {
@@ -585,7 +585,7 @@ static void convert_ir2x86asm(IR* ir){
                 } else {
                     if(ident->reloc){
                         // 初期化あり
-                        print("\t.global\t%s\n", ident->name);
+                        print("\t.globl\t%s\n", ident->name);
                         set_section(DATA);
                         print("%s:\n", ir->s1->ident->name);
                         if(!(ident->reloc->label)){
@@ -607,7 +607,7 @@ static void convert_ir2x86asm(IR* ir){
                             print("  .quad %s\n", ident->reloc->label);
                         }
                     } else {
-                        print("\t.global\t%s\n", ident->name);
+                        print("\t.globl\t%s\n", ident->name);
                         set_section(BSS);
                         print("\t.type\t%s, @object\n", ident->name);
                         print("\t.size\t%s, %d\n", ident->name, ir->s2->val);

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,10 @@ int main(int argc, char **argv){
     gen_ir();
     gen_x86();
 
+    if(debug_exec){
+        dwarf();
+    }
+
     close_output_file();
 
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv){
     gen_x86();
 
     if(debug_exec){
-        dwarf();
+       dwarf();
     }
 
     close_output_file();

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv){
     file_init();
     init_preprocess();
     cinfo.compiler = "mcc2";
+    cinfo.global_scope = get_global_scope();
 
     if(argc > 2){
         analy_opt(argc, argv);

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 
 static char* filename = NULL;
 bool is_preprocess = false;
+CompilationInfo cinfo;
 
 // デバッグモードを有効化する関数
 void enable_debug_mode(const char *mode) {
@@ -21,6 +22,8 @@ void analy_opt(int argc, char** argv){
         switch(opt){
             case 'c':
                 filename = optarg;
+                cinfo.compile_file = optarg;
+                cinfo.working_dir = get_dirname(optarg);
                 break;
             case 'i':
                 if(optarg != NULL) {
@@ -67,6 +70,7 @@ int main(int argc, char **argv){
     ty_init();
     file_init();
     init_preprocess();
+    cinfo.compiler = "mcc2";
 
     if(argc > 2){
         analy_opt(argc, argv);

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,6 @@ void analy_opt(int argc, char** argv){
         switch(opt){
             case 'c':
                 filename = optarg;
-                cinfo.compile_file = optarg;
                 cinfo.working_dir = get_dirname(optarg);
                 break;
             case 'i':

--- a/src/mcc2.h
+++ b/src/mcc2.h
@@ -44,11 +44,10 @@ typedef enum TypeKind TypeKind;
 
 extern FILE* fp;
 extern char* builtin_def;
-extern SrcFile* main_file;
 extern CompilationInfo cinfo;
 
 struct CompilationInfo{
-    char*       compile_file;
+    SrcFile*    compile_file;
     char*       working_dir;
     char*       compiler;
     Scope*      global_scope;

--- a/src/mcc2.h
+++ b/src/mcc2.h
@@ -596,6 +596,9 @@ void print(char* fmt, ...);
 void open_output_file(char* filename);
 void close_output_file();
 
+// dwarf.c
+void dwarf();
+
 // gen_ir.c
 void gen_ir();
 

--- a/src/mcc2.h
+++ b/src/mcc2.h
@@ -19,6 +19,7 @@
 #include <bits/getopt_core.h>
 #endif
 
+typedef struct CompilationInfo CompilationInfo;
 typedef struct Token Token;
 typedef struct Node Node;
 typedef struct Parameter Parameter;
@@ -44,6 +45,13 @@ typedef enum TypeKind TypeKind;
 extern FILE* fp;
 extern char* builtin_def;
 extern SrcFile* main_file;
+extern CompilationInfo cinfo;
+
+struct CompilationInfo{
+    char* compile_file;
+    char* working_dir;
+    char* compiler;
+};
 
 struct IncludePath {
     char* path;

--- a/src/mcc2.h
+++ b/src/mcc2.h
@@ -48,9 +48,10 @@ extern SrcFile* main_file;
 extern CompilationInfo cinfo;
 
 struct CompilationInfo{
-    char* compile_file;
-    char* working_dir;
-    char* compiler;
+    char*       compile_file;
+    char*       working_dir;
+    char*       compiler;
+    Scope*      global_scope;
 };
 
 struct IncludePath {

--- a/src/mcc2.h
+++ b/src/mcc2.h
@@ -472,10 +472,6 @@ typedef enum IRCmd{
     IR_COMMENT,
         // comment (string)
         // stringをコメントとして出力する
-        IR_FILE_SECTION,
-        // file (null) (string)
-        // ファイル名を設定する
-
 } IRCmd;
 
 /*

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -3,7 +3,6 @@
 
 Token* token;
 SrcFile* cur_file;
-SrcFile* main_file;
 extern bool is_preprocess;
 static long row = 0;
 static char* row_start = NULL;
@@ -21,8 +20,8 @@ Token* delete_newline_token(Token* tok);
 Token* tokenize(char* path){
     SrcFile* file = read_file(path);
     cur_file = file;
-    if(!main_file){
-        main_file = file;
+    if(!cinfo.compile_file){
+        cinfo.compile_file = file;
     }
 
     Token* tok = scan(file->body);


### PR DESCRIPTION
以下のセクションを出力し、ラインデバッグに対応
- .debug_info (compilation unitのみ出力)
- .debug_abbrev (compilation unitのみ出力)
- .debug_ling (ラベルだけ出力、行番号プログラムはGASにまかせる)
- .debug_str (compilation unit用)